### PR TITLE
Fixed build instructions for cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The code uses:
 #### Build with `CMake`
 
 ```
-$ mkdir build && cmake ../ && make -j
+$ mkdir build && cd build && cmake ../ && make -j
 ```
 
 #### Build with `Meson`


### PR DESCRIPTION
Adds a `cd build` after the `mkdir build`.